### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/mh_cv_ac_latex.tex
+++ b/mh_cv_ac_latex.tex
@@ -187,7 +187,7 @@ includemp]{geometry}
 	\newcommand{\halfblankline}{\quad\vspace{-0.5\baselineskip}\pagebreak[3]}
 	
 	% Uses hyperref to link DOI
-	\newcommand\doilink[1]{\href{http://dx.doi.org/#1}{#1}}
+	\newcommand\doilink[1]{\href{https://doi.org/#1}{#1}}
 	\newcommand\doi[1]{doi:\doilink{#1}}
 	
 	% For \url{SOME_URL}, links SOME_URL to the url SOME_URL


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates the code that generates your DOI links.

Cheers!